### PR TITLE
Import Selector type from "oaf-side-effects" instead of "unique-selector"

### DIFF
--- a/src/page-state.ts
+++ b/src/page-state.ts
@@ -11,6 +11,8 @@ import {
 import unique from "unique-selector";
 import { is } from "./is";
 
+type Selector = string | undefined;
+
 /**
  * Aspects of page state that should be restored after POP history
  * actions (i.e. after the user navigates back or forward in their browser).
@@ -19,7 +21,7 @@ export type PageState = ScrollPosition & {
   /**
    * A CSS selector that uniquely specifies the element that has keyboard focus (if any).
    */
-  readonly focusSelector?: any;
+  readonly focusSelector?: Selector;
 };
 
 /**

--- a/src/page-state.ts
+++ b/src/page-state.ts
@@ -6,12 +6,11 @@ import {
   focusElement,
   getScrollPosition,
   ScrollPosition,
+  Selector,
   setScrollPosition,
 } from "oaf-side-effects";
 import unique from "unique-selector";
 import { is } from "./is";
-
-type Selector = string | undefined;
 
 /**
  * Aspects of page state that should be restored after POP history

--- a/src/page-state.ts
+++ b/src/page-state.ts
@@ -8,7 +8,7 @@ import {
   ScrollPosition,
   setScrollPosition,
 } from "oaf-side-effects";
-import unique, { Selector } from "unique-selector";
+import unique from "unique-selector";
 import { is } from "./is";
 
 /**
@@ -19,7 +19,7 @@ export type PageState = ScrollPosition & {
   /**
    * A CSS selector that uniquely specifies the element that has keyboard focus (if any).
    */
-  readonly focusSelector?: Selector;
+  readonly focusSelector?: any;
 };
 
 /**


### PR DESCRIPTION
Otherwise i get this Typescript error:
```
TypeScript error in .../node_modules/oaf-routing/dist/page-state.d.ts(11,30):
Cannot use namespace 'Selector' as a type.  TS2709

     9 |      * A CSS selector that uniquely specifies the element that has keyboard focus (if any).
    10 |      */
  > 11 |     readonly focusSelector?: Selector;
       |                              ^
    12 | };
    13 | /**
    14 |  * Get the current page state.

```

Typescript version: 3.5.3
OS: Windows 10 2004 (build 19041.388)
NodeJS: v12.13.0
Framework: React 16.8.6 (react-scripts)